### PR TITLE
Change preload paths to relative paths

### DIFF
--- a/addons/Targets/Scripts/DamageNumberScript.gd
+++ b/addons/Targets/Scripts/DamageNumberScript.gd
@@ -13,7 +13,7 @@ enum DamageType{
 }
 
 # Labels
-var damageNumber : PackedScene = preload("res://godot-simple-fps-weapon-system/addons/Targets/Scenes/DamageNumberScene.tscn")
+var damageNumber : PackedScene = preload("../../Targets/Scenes/DamageNumberScene.tscn")
 
 # Colors
 var normalColor : Color = Color(248, 248, 242, 255)

--- a/addons/Weapons/Scripts/ProjectileScript.gd
+++ b/addons/Weapons/Scripts/ProjectileScript.gd
@@ -12,11 +12,11 @@ var bodiesList : Array = []
 @onready var hitbox = $Hitbox
 
 @export_group("Sound variables")
-@onready var audioManager : PackedScene = preload("res://godot-simple-fps-weapon-system/addons/Misc/Scenes/AudioManagerScene.tscn")
+@onready var audioManager : PackedScene = preload("../../Misc/Scenes/AudioManagerScene.tscn")
 @export var explosionSound : AudioStream
 
 @export_group("Particles variables")
-@onready var particlesManager : PackedScene = preload("res://godot-simple-fps-weapon-system/addons/Misc/Scenes/ParticlesManagerScene.tscn")
+@onready var particlesManager : PackedScene = preload("../../Misc/Scenes/ParticlesManagerScene.tscn")
 
 func _process(delta):
 	if timeBeforeVanish > 0.0: timeBeforeVanish -= delta

--- a/addons/Weapons/Scripts/WeaponManagerScript.gd
+++ b/addons/Weapons/Scripts/WeaponManagerScript.gd
@@ -34,8 +34,8 @@ var rng = RandomNumberGenerator.new()
 @onready var ammoManager : Node3D = %AmmunitionManager
 @onready var animPlayer : AnimationPlayer = %AnimationPlayer
 @onready var animManager : Node3D = %AnimationManager
-@onready var audioManager : PackedScene = preload("res://godot-simple-fps-weapon-system/addons/Misc/Scenes/AudioManagerScene.tscn")
-@onready var bulletDecal : PackedScene = preload("res://godot-simple-fps-weapon-system/addons/Weapons/Scenes/BulletDecalScene.tscn")
+@onready var audioManager : PackedScene = preload("../../Misc/Scenes/AudioManagerScene.tscn")
+@onready var bulletDecal : PackedScene = preload("../../Weapons/Scenes/BulletDecalScene.tscn")
 @onready var hud : CanvasLayer = %HUD
 @onready var linkComponent : Node3D = %LinkComponent
 


### PR DESCRIPTION
Fixes path errors on default and non-`godot-simple-fps-weapon-system` addon paths.

Fixes #2 